### PR TITLE
Add support for .inc file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Encoded file extensions:
 - `.hp`
 - `.hpp`
 - `.hxx`
+- `.inc`
 
 ## Usage
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ fn is_text_file(path: &Path) -> bool {
         || ext == OsStr::new("hp")
         || ext == OsStr::new("hpp")
         || ext == OsStr::new("hxx")
+        || ext == OsStr::new("inc")
 }
 
 macro_rules! debug_println {


### PR DESCRIPTION
Adds `.inc` as a hardcoded extension to check, which is used by some games such as Wind Waker and Twilight Princess.

Tested and it fixes this:
https://github.com/zeldaret/tp/blob/5302ec4555a08a2537abc1c408a518995d5e5dbc/src/d/d_event_debug.cpp#L13-L16